### PR TITLE
Fix ref to OHTTP

### DIFF
--- a/draft-guidelines.md
+++ b/draft-guidelines.md
@@ -702,7 +702,7 @@ Example: In the development of the IPv6 protocol, it was discussed to embed a Me
 Example:
 Generally, pseudonymous identifiers cannot be simply reverse engineered. Some early approaches took approaches such as simple hashing of IP addresses, but these could then be simply reversed by generating a hash for each potential IP address and comparing it to the pseudonym. 
 
-Example: There are also efforts for application layer protocols, like Oblivious HTTP, {{draft-ietf-ohai-ohttp/}}, that can separate identifiers from requests.
+Example: There are also efforts for application layer protocols, like Oblivious HTTP, {{draft-ietf-ohai-ohttp}}, that can separate identifiers from requests.
 
 Impacts:
 


### PR DESCRIPTION
This fixes a compilation error.

As an aside, kramdown does not require you to add reference definitions upfront. So, for instance, you could remove this clause.

```
   draft-ietf-ohai-ohttp:
     title: Oblivious DNS Over HTTPS
     date: 2023
     author:
        - ins: M. Thomson
        - ins: C. A. Wood
     target: https://datatracker.ietf.org/doc/html/draft-ietf-ohai-ohttp
```
